### PR TITLE
Fix: terraform action failing when terraform files would not contain a module

### DIFF
--- a/test/terraform/without_module.tf
+++ b/test/terraform/without_module.tf
@@ -1,0 +1,1 @@
+data "aws_region" "current" {}


### PR DESCRIPTION
# Description

It was noticed, that the github action would sometimes fail with:

```
Parsing dependencies information
KeyError: key not found: "module_calls"
  /usr/local/bundle/bundler/gems/dependabot-core-de390f394af5/terraform/lib/dependabot/terraform/file_parser.rb:45:in `fetch'
  /usr/local/bundle/bundler/gems/dependabot-core-de390f394af5/terraform/lib/dependabot/terraform/file_parser.rb:45:in `parse_terraform_file'
  /usr/local/bundle/bundler/gems/dependabot-core-de390f394af5/terraform/lib/dependabot/terraform/file_parser.rb:26:in `block in parse'
  /usr/local/bundle/bundler/gems/dependabot-core-de390f394af5/terraform/lib/dependabot/terraform/file_parser.rb:25:in `each'
  /usr/local/bundle/bundler/gems/dependabot-core-de390f394af5/terraform/lib/dependabot/terraform/file_parser.rb:25:in `parse'
  /usr/src/app/dependabot.rb:99:in `<top (required)>'
bundler: failed to load command: ./dependabot.rb (./dependabot.rb)
```

Further investigation into that showed, that dependabot-core has a bug where it will fail, if files do not contain modules. This was addressed in https://github.com/patrickjahns/dependabot-core/commit/285f18f1743636b0372873d4aee93ebc27c9925a and should now work as expected

This PR just contains a test, as the dependencies will be automatically updated 


closes #18 