### PR TITLE
feat: allow for specifying multiple paths in the repository

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: build container
         run: docker build -t patrickjahns/dependabot-terraform-action:${{ github.sha }} .
       - name: test container
-        run: test/test.sh ${{ github.sha }}
+        run: test/test.sh ${{ github.sha }} feature_multiple_paths
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEPENDENCY_GITHUB_TOKEN: ${{ secrets.DEPENDENCY_GITHUB_TOKEN }}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: build container
         run: docker build -t patrickjahns/dependabot-terraform-action:${{ github.sha }} .
       - name: test container
-        run: test/test.sh ${{ github.sha }} feature_multiple_paths
+        run: test/test.sh ${{ github.sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEPENDENCY_GITHUB_TOKEN: ${{ secrets.DEPENDENCY_GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ The github action was created, as dependabot currently [does not yet officially 
   with:
     # Where to look for terraform files to check for dependency upgrades.
     # The directory is relative to the repository's root.
+    # Multiple paths can be provided by splitting them with a new line.
+    # Example:
+    #   directory: |
+    #     /path/to/first/module
+    #     /path/to/second/module
     # Default: "/"
     directory: ''
 

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,11 @@ inputs:
     description: >
       Where to look for terraform files to check for dependency upgrades.
       The directory is relative to the repository's root.
+      Multiple paths can be provided by splitting them with a new line.
+      Example:
+        directory: |
+          /path/to/first/module
+          /path/to/second/module
     default: "/"
     required: false
   target_branch:

--- a/src/dependabot.rb
+++ b/src/dependabot.rb
@@ -19,13 +19,11 @@ end
 
 # Directory where the base dependency files are.
 directory = ENV["INPUT_DIRECTORY"] || "/"
+directory = directory.gsub(/\\n/, "\n")
 if directory.empty?
   print "The directory needs to be set"
   exit(1)
 end
-
-# Hardcode the package manager to terraform
-package_manager = "terraform"
 
 # Define the target branch
 target_branch = ENV["INPUT_TARGET_BRANCH"]
@@ -64,96 +62,104 @@ unless dependency_token.empty?
   )
 end
 
+def update(source, credentials_repository, credentials_dependencies)
 
+  # Hardcode the package manager to terraform
+  package_manager = "terraform"
 
-source = Dependabot::Source.new(
-  provider: "github",
-  repo: repo_name,
-  directory: directory,
-  branch: target_branch,
-)
-
-
-##############################
-# Fetch the dependency files #
-##############################
-puts "Fetching #{package_manager} dependency files for #{repo_name}"
-fetcher = Dependabot::FileFetchers.for_package_manager(package_manager).new(
-  source: source,
-  credentials: credentials_repository,
-)
-
-files = fetcher.files
-commit = fetcher.commit
-
-##############################
-# Parse the dependency files #
-##############################
-puts "Parsing dependencies information"
-parser = Dependabot::FileParsers.for_package_manager(package_manager).new(
-  dependency_files: files,
-  source: source,
-  credentials: credentials_repository,
-)
-
-dependencies = parser.parse
-
-dependencies.select(&:top_level?).each do |dep|
-  #########################################
-  # Get update details for the dependency #
-  #########################################
-  checker = Dependabot::UpdateCheckers.for_package_manager(package_manager).new(
-    dependency: dep,
-    dependency_files: files,
-    credentials: credentials_dependencies,
+  ##############################
+  # Fetch the dependency files #
+  ##############################
+  fetcher = Dependabot::FileFetchers.for_package_manager(package_manager).new(
+    source: source,
+    credentials: credentials_repository,
   )
 
-  next if checker.up_to_date?
+  files = fetcher.files
+  commit = fetcher.commit
 
-  requirements_to_unlock =
-    if !checker.requirements_unlocked_or_can_be?
-      if checker.can_update?(requirements_to_unlock: :none) then :none
+  ##############################
+  # Parse the dependency files #
+  ##############################
+  puts "  - Parsing dependencies information"
+  parser = Dependabot::FileParsers.for_package_manager(package_manager).new(
+    dependency_files: files,
+    source: source,
+    credentials: credentials_repository,
+  )
+
+  dependencies = parser.parse
+
+  dependencies.select(&:top_level?).each do |dep|
+    #########################################
+    # Get update details for the dependency #
+    #########################################
+    checker = Dependabot::UpdateCheckers.for_package_manager(package_manager).new(
+      dependency: dep,
+      dependency_files: files,
+      credentials: credentials_dependencies,
+    )
+
+    next if checker.up_to_date?
+
+    requirements_to_unlock =
+      if !checker.requirements_unlocked_or_can_be?
+        if checker.can_update?(requirements_to_unlock: :none) then :none
+        else :update_not_possible
+        end
+      elsif checker.can_update?(requirements_to_unlock: :own) then :own
+      elsif checker.can_update?(requirements_to_unlock: :all) then :all
       else :update_not_possible
       end
-    elsif checker.can_update?(requirements_to_unlock: :own) then :own
-    elsif checker.can_update?(requirements_to_unlock: :all) then :all
-    else :update_not_possible
-    end
 
-  next if requirements_to_unlock == :update_not_possible
+    next if requirements_to_unlock == :update_not_possible
 
-  updated_deps = checker.updated_dependencies(
-    requirements_to_unlock: requirements_to_unlock
-  )
+    updated_deps = checker.updated_dependencies(
+      requirements_to_unlock: requirements_to_unlock
+    )
 
-  #####################################
-  # Generate updated dependency files #
-  #####################################
-  print "  - Updating #{dep.name} (from #{dep.version})…"
-  updater = Dependabot::FileUpdaters.for_package_manager(package_manager).new(
-    dependencies: updated_deps,
-    dependency_files: files,
-    credentials: credentials_repository,
-  )
+    #####################################
+    # Generate updated dependency files #
+    #####################################
+    print "  - Updating #{dep.name} (from #{dep.version})…"
+    updater = Dependabot::FileUpdaters.for_package_manager(package_manager).new(
+      dependencies: updated_deps,
+      dependency_files: files,
+      credentials: credentials_repository,
+    )
 
-  updated_files = updater.updated_dependency_files
+    updated_files = updater.updated_dependency_files
 
-  ########################################
-  # Create a pull request for the update #
-  ########################################
-  pr_creator = Dependabot::PullRequestCreator.new(
-    source: source,
-    base_commit: commit,
-    dependencies: updated_deps,
-    files: updated_files,
-    credentials: credentials_repository,
-    label_language: false,
-  )
-  pull_request = pr_creator.create
-  puts " submitted"
+    ########################################
+    # Create a pull request for the update #
+    ########################################
+    pr_creator = Dependabot::PullRequestCreator.new(
+      source: source,
+      base_commit: commit,
+      dependencies: updated_deps,
+      files: updated_files,
+      credentials: credentials_repository,
+      label_language: false,
+    )
+    pull_request = pr_creator.create
+    puts "  - submitted"
 
-  next unless pull_request
+    next unless pull_request
 
+  end
 end
 
-puts "Done"
+puts "  - Fetching dependency files for #{repo_name}"
+directory.split("\n").each do |dir|
+  puts "  - Checking #{dir} ..."
+
+  source = Dependabot::Source.new(
+    provider: "github",
+    repo: repo_name,
+    directory: dir,
+    branch: target_branch,
+  )
+  update source, credentials_repository, credentials_dependencies
+end
+
+puts "  - Done"

--- a/src/dependabot.rb
+++ b/src/dependabot.rb
@@ -156,7 +156,7 @@ directory.split("\n").each do |dir|
   source = Dependabot::Source.new(
     provider: "github",
     repo: repo_name,
-    directory: dir,
+    directory: dir.strip!,
     branch: target_branch,
   )
   update source, credentials_repository, credentials_dependencies

--- a/test/second/main.tf
+++ b/test/second/main.tf
@@ -1,0 +1,12 @@
+module "public" {
+  source = "git@github.com:patrickjahns/terraform-module-public.git?ref=0.0.0"
+}
+
+module "private" {
+  source = "git@github.com:patrickjahns/terraform-module-private.git?ref=0.0.0"
+}
+
+module "registry_module" {
+  source  = "vancluever/module/null"
+  version = "1.0.0"
+}

--- a/test/test.sh
+++ b/test/test.sh
@@ -55,10 +55,30 @@ test_container_runs_successfully_on_local_repository() {
     print_nl
 }
 
+test_container_runs_successfully_on_local_repository_with_multiple_dirs() {
+    print_start "Testing the container runs successfully"
+    docker run -e INPUT_TARGET_BRANCH="master" \
+               -e INPUT_GITHUB_DEPENDENCY_TOKEN="${DEPENDENCY_GITHUB_TOKEN}" \
+               -e INPUT_TOKEN="${GITHUB_TOKEN}" \
+               -e GITHUB_REPOSITORY="patrickjahns/dependabot-terraform-action" \
+               -e INPUT_DIRECTORY="/test/terraform\n/test/second" \
+               --rm ${CONTAINER_IMAGE}:${CONTAINER_SHA}
+    retVal=$?
+    print_end
+    if [[ ${retVal} -ne 0 ]]; then
+      print_error "FAILURE"
+      RESULT=1
+    else
+      print_success "SUCCESS"
+    fi
+    print_nl
+}
+
 main() {
     print_default "Starting test suite .."
     pushd $SCRIPT_DIR > /dev/null
         test_container_runs_successfully_on_local_repository
+        test_container_runs_successfully_on_local_repository_with_multiple_dirs
     popd > /dev/null
     if [[ ${RESULT} -ne 0 ]]; then
       print_error "FAILURE"

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 
+set -x
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 CONTAINER_IMAGE=${IMAGE:-"patrickjahns/dependabot-terraform-action"}
 CONTAINER_SHA=${1:-"latest"}
+CURRENT_BRANCH=${2:-"master"}
 RESULT=0
 
 # Colors
@@ -38,7 +41,7 @@ print_nl() {
 
 test_container_runs_successfully_on_local_repository() {
     print_start "Testing the container runs successfully"
-    docker run -e INPUT_TARGET_BRANCH="master" \
+    docker run -e INPUT_TARGET_BRANCH="${CURRENT_BRANCH}" \
                -e INPUT_GITHUB_DEPENDENCY_TOKEN="${DEPENDENCY_GITHUB_TOKEN}" \
                -e INPUT_TOKEN="${GITHUB_TOKEN}" \
                -e GITHUB_REPOSITORY="patrickjahns/dependabot-terraform-action" \
@@ -57,7 +60,7 @@ test_container_runs_successfully_on_local_repository() {
 
 test_container_runs_successfully_on_local_repository_with_multiple_dirs() {
     print_start "Testing the container runs successfully"
-    docker run -e INPUT_TARGET_BRANCH="master" \
+    docker run -e INPUT_TARGET_BRANCH="${CURRENT_BRANCH}" \
                -e INPUT_GITHUB_DEPENDENCY_TOKEN="${DEPENDENCY_GITHUB_TOKEN}" \
                -e INPUT_TOKEN="${GITHUB_TOKEN}" \
                -e GITHUB_REPOSITORY="patrickjahns/dependabot-terraform-action" \


### PR DESCRIPTION
# Motivation

The action should be able to update terraform modules in various paths in the same repository

# Description

Adds the ability to specify several paths for scanning for dependencies by splitting them with a newline. Example:

```
jobs:
  dependabot-terraform:
    runs-on: ubuntu-latest
    steps:
      - name: update terraform dependencies
        uses: patrickjahns/dependabot-terraform-action@v1
        with:
          github_dependency_token: ${{ secrets.DEPENDENCY_GITHUB_TOKEN }}
          directory: |
           /first/path
           /second/path
```

fixes #17 